### PR TITLE
[M1-1.2] Implement Multiboot2 Header and Boot Infrastructure

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,4 +9,6 @@ build-std-features = ["compiler-builtins-mem"]
 rustflags = [
     "-C", "link-arg=--nmagic",
     "-C", "link-arg=--no-dynamic-linker",
+    "-C", "link-arg=-Tkernel/linker.ld",
+    "-C", "relocation-model=static",
 ]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,3 +9,7 @@ bitflags = "2.4"
 
 [lib]
 crate-type = ["staticlib"]
+
+[[bin]]
+name = "yomi-kernel"
+path = "src/main.rs"

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -1,0 +1,43 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let src_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+
+    // List of assembly files to compile
+    let asm_files = vec![
+        ("multiboot2.asm", "multiboot2.o"),
+        ("boot.asm", "boot.o"),
+    ];
+
+    let mut object_files = Vec::new();
+
+    for (asm_name, obj_name) in &asm_files {
+        let asm_file = src_dir.join("src/boot").join(asm_name);
+        let obj_file = out_dir.join(obj_name);
+
+        println!("cargo:rerun-if-changed={}", asm_file.display());
+
+        let status = Command::new("nasm")
+            .args([
+                "-f", "elf64",
+                "-o", obj_file.to_str().unwrap(),
+                asm_file.to_str().unwrap(),
+            ])
+            .status()
+            .expect("Failed to execute nasm. Make sure nasm is installed.");
+
+        if !status.success() {
+            panic!("Failed to compile assembly file: {}", asm_file.display());
+        }
+
+        object_files.push(obj_file);
+    }
+
+    // Link the object files directly
+    for obj_file in &object_files {
+        println!("cargo:rustc-link-arg={}", obj_file.display());
+    }
+}

--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -5,11 +5,13 @@ SECTIONS {
 
     .boot :
     {
+        KEEP(*(.multiboot2))
         KEEP(*(.multiboot_header))
     }
 
     .text : ALIGN(4K)
     {
+        KEEP(*(.text._start))
         *(.text .text.*)
     }
 

--- a/kernel/src/boot/boot.asm
+++ b/kernel/src/boot/boot.asm
@@ -1,0 +1,29 @@
+global _start
+extern kernel_main
+
+section .bss
+align 16
+stack_bottom:
+    resb 16384  ; 16 KiB stack
+stack_top:
+
+section .text._start
+bits 32
+_start:
+    ; Set up stack pointer
+    mov esp, stack_top
+
+    ; Save multiboot2 magic and info pointer
+    ; EAX contains magic number
+    ; EBX contains pointer to multiboot2 info structure
+    push ebx    ; Push multiboot2 info pointer (2nd argument)
+    push eax    ; Push magic number (1st argument)
+
+    ; Call the kernel main function
+    call kernel_main
+
+    ; If kernel_main returns, hang
+    cli
+.hang:
+    hlt
+    jmp .hang

--- a/kernel/src/boot/mod.rs
+++ b/kernel/src/boot/mod.rs
@@ -1,0 +1,8 @@
+/// Boot-related functionality
+///
+/// This module contains boot protocol implementations and
+/// early initialization code.
+
+pub mod multiboot2;
+
+pub use multiboot2::{Multiboot2Info, MemoryRegion, MemoryRegionType};

--- a/kernel/src/boot/multiboot2.asm
+++ b/kernel/src/boot/multiboot2.asm
@@ -1,0 +1,49 @@
+section .multiboot2
+align 8
+
+multiboot2_header_start:
+    ; Multiboot2 magic number
+    dd 0xE85250D6
+
+    ; Architecture (0 = i386 protected mode)
+    dd 0
+
+    ; Header length
+    dd multiboot2_header_end - multiboot2_header_start
+
+    ; Checksum
+    dd -(0xE85250D6 + 0 + (multiboot2_header_end - multiboot2_header_start))
+
+    ; --- Tags start ---
+
+    ; Information request tag
+    align 8
+    dw 1        ; type = 1 (information request)
+    dw 0        ; flags = 0
+    dd 20       ; size
+    dd 3        ; memory map
+    dd 6        ; memory info
+    dd 8        ; framebuffer info
+
+    ; Framebuffer tag
+    align 8
+    dw 5        ; type = 5 (framebuffer)
+    dw 0        ; flags = 0
+    dd 20       ; size
+    dd 1024     ; width
+    dd 768      ; height
+    dd 32       ; depth
+
+    ; Module alignment tag
+    align 8
+    dw 6        ; type = 6 (module alignment)
+    dw 0        ; flags = 0
+    dd 8        ; size
+
+    ; End tag
+    align 8
+    dw 0        ; type = 0 (end)
+    dw 0        ; flags = 0
+    dd 8        ; size
+
+multiboot2_header_end:

--- a/kernel/src/boot/multiboot2.rs
+++ b/kernel/src/boot/multiboot2.rs
@@ -1,0 +1,102 @@
+/// Multiboot2 information handling
+///
+/// This module provides types and functions for extracting information
+/// passed by the bootloader (GRUB2) via Multiboot2 protocol.
+
+/// Multiboot2 magic number (passed in EAX by bootloader)
+pub const MULTIBOOT2_MAGIC: u32 = 0x36d76289;
+
+/// Multiboot2 information structure
+pub struct Multiboot2Info {
+    /// Address of boot information structure passed by bootloader
+    info_addr: usize,
+}
+
+impl Multiboot2Info {
+    /// Initialize from magic number and address
+    ///
+    /// # Safety
+    /// The caller must ensure that `info_addr` points to a valid
+    /// Multiboot2 information structure in memory.
+    pub unsafe fn from_ptr(magic: u32, info_addr: usize) -> Option<Self> {
+        if magic == MULTIBOOT2_MAGIC {
+            Some(Self { info_addr })
+        } else {
+            None
+        }
+    }
+
+    /// Get memory map iterator
+    pub fn memory_map(&self) -> impl Iterator<Item = MemoryRegion> {
+        // TODO: Parse Multiboot2 information to extract memory map
+        core::iter::empty()
+    }
+
+    /// Get framebuffer information
+    pub fn framebuffer_info(&self) -> Option<FramebufferInfo> {
+        // TODO: Parse Multiboot2 information to extract framebuffer info
+        None
+    }
+
+    /// Get total memory size
+    pub fn total_memory(&self) -> Option<usize> {
+        // TODO: Parse Multiboot2 information to extract memory info
+        None
+    }
+}
+
+/// Memory region descriptor
+#[derive(Debug, Clone, Copy)]
+pub struct MemoryRegion {
+    /// Base physical address of the region
+    pub base_addr: u64,
+    /// Length of the region in bytes
+    pub length: u64,
+    /// Type of memory region
+    pub region_type: MemoryRegionType,
+}
+
+/// Memory region type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum MemoryRegionType {
+    /// Usable RAM
+    Usable = 1,
+    /// Reserved by hardware/BIOS
+    Reserved = 2,
+    /// ACPI reclaimable memory
+    AcpiReclaimable = 3,
+    /// ACPI NVS memory
+    AcpiNvs = 4,
+    /// Bad memory
+    BadMemory = 5,
+}
+
+/// Framebuffer information
+#[derive(Debug, Clone, Copy)]
+pub struct FramebufferInfo {
+    /// Physical address of framebuffer
+    pub addr: u64,
+    /// Pitch (bytes per line)
+    pub pitch: u32,
+    /// Width in pixels
+    pub width: u32,
+    /// Height in pixels
+    pub height: u32,
+    /// Bits per pixel
+    pub bpp: u8,
+    /// Framebuffer type
+    pub fb_type: FramebufferType,
+}
+
+/// Framebuffer type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FramebufferType {
+    /// Indexed color
+    Indexed = 0,
+    /// RGB color
+    Rgb = 1,
+    /// EGA text mode
+    EgaText = 2,
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -2,6 +2,10 @@
 
 use core::panic::PanicInfo;
 
+pub mod boot;
+
+pub use boot::{Multiboot2Info, MemoryRegion, MemoryRegionType};
+
 /// Kernel initialization function
 pub fn init() {
     // Kernel initialization code will go here

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1,0 +1,37 @@
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+mod boot;
+use boot::multiboot2::Multiboot2Info;
+
+/// Kernel entry point called from boot.asm
+///
+/// # Arguments
+/// * `magic` - Multiboot2 magic number (should be 0x36d76289)
+/// * `info_addr` - Physical address of Multiboot2 information structure
+#[no_mangle]
+pub extern "C" fn kernel_main(magic: u32, info_addr: usize) -> ! {
+    // Initialize multiboot2 information
+    let _multiboot_info = unsafe { Multiboot2Info::from_ptr(magic, info_addr) };
+
+    // TODO: Initialize kernel subsystems
+    // init();
+
+    // Hang
+    loop {
+        unsafe {
+            core::arch::asm!("hlt");
+        }
+    }
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {
+        unsafe {
+            core::arch::asm!("hlt");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements Multiboot2 header and boot infrastructure for GRUB2 bootloader compatibility. This is the foundation for kernel loading and provides the interface for receiving boot information (memory map, framebuffer, etc.) from the bootloader.

**Related Issue**: #002 (docs/issues/002-multiboot2-header.md)

## Changes

### New Files

#### Assembly Files
- **`kernel/src/boot/multiboot2.asm`** - Multiboot2 header implementation
  - Magic number: `0xE85250D6`
  - Architecture: i386 protected mode
  - Information request tags (memory map, memory info, framebuffer)
  - Framebuffer configuration: 1024x768x32

- **`kernel/src/boot/boot.asm`** - Boot entry point
  - 32-bit entry point (`_start`)
  - Stack initialization (16 KiB)
  - Multiboot2 parameter passing to kernel_main

#### Rust Files
- **`kernel/src/boot/multiboot2.rs`** - Rust interface for Multiboot2
  - `Multiboot2Info` type for boot information extraction
  - `MemoryRegion` type for memory map entries
  - `FramebufferInfo` type for display configuration
  - Magic number verification

- **`kernel/src/boot/mod.rs`** - Boot module exports

- **`kernel/src/main.rs`** - Kernel main entry point
  - `kernel_main` function accepting Multiboot2 parameters
  - Basic panic handler

#### Build System
- **`kernel/build.rs`** - Assembly compilation
  - NASM invocation for assembly files
  - Object file linking

### Modified Files

- **`kernel/linker.ld`**
  - Added `.boot` section at 0x100000 (1MB)
  - Ensured `.multiboot2` section placement at start
  - Added `.text._start` section ordering

- **`.cargo/config.toml`**
  - Added linker script flag: `-Tkernel/linker.ld`
  - Added relocation model: `static`

- **`kernel/Cargo.toml`**
  - Added binary target configuration

- **`kernel/src/lib.rs`**
  - Exported boot module

## Implementation Details

### Memory Layout

```
Address         Section         Content
0x100000        .boot           Multiboot2 header (80 bytes)
0x101000        .text           Entry point (_start)
0x102000        .bss            Stack (16 KiB)
```

### Multiboot2 Header Structure

```
Offset  Size  Content               Value
0x00    4     Magic number          0xE85250D6
0x04    4     Architecture          0x00000000 (i386)
0x08    4     Header length         80 bytes
0x0C    4     Checksum              (calculated)
0x10    -     Tags                  Information requests
```

### Boot Flow

```
GRUB2 loads kernel
  ↓
Finds Multiboot2 header at 0x100000
  ↓
Verifies magic number (0xE85250D6)
  ↓
Processes information request tags
  ↓
Jumps to _start (0x101000)
  ↓
_start sets up stack
  ↓
_start passes parameters (EAX=magic, EBX=info_addr)
  ↓
Calls kernel_main(magic, info_addr)
```

## Verification

### Section Placement ✅

```bash
$ objdump -h target/x86_64-unknown-none/debug/yomi-kernel

Idx Name          Size      VMA               LMA
  0 .boot         00000050  0000000000100000  0000000000100000
  1 .text         0000007f  0000000000101000  0000000000101000
  2 .bss          00004000  0000000000102000  0000000000102000
```

### Multiboot2 Header Content ✅

```bash
$ objdump -s -j .boot target/x86_64-unknown-none/debug/yomi-kernel

Contents of section .boot:
 100000 d65052e8 00000000 50000000 daaead17
        ^^^^^^^^ = 0xE85250D6 (Magic) ✓
        00000000 = i386 protected mode ✓
        50000000 = 80 bytes length ✓
        daaead17 = Checksum ✓
```

### Entry Point ✅

```bash
$ readelf -h target/x86_64-unknown-none/debug/yomi-kernel | grep Entry

Entry point address: 0x101000
```

### Symbols ✅

```bash
$ nm target/x86_64-unknown-none/debug/yomi-kernel

0000000000101000 T _start
0000000000101060 T kernel_main
0000000000100000 r multiboot2_header_start
```

## Testing

### Build Test

```bash
$ cargo build --package yomi-kernel
   Compiling yomi-kernel v0.1.0
    Finished `dev` profile
```

**Result**: ✅ Build successful (warnings only, no errors)

### Header Verification

```bash
$ hexdump -C target/x86_64-unknown-none/debug/yomi-kernel | head -20
```

**Result**: ✅ Multiboot2 header correctly placed at file offset 0x120

### Symbol Verification

```bash
$ nm target/x86_64-unknown-none/debug/yomi-kernel | grep -E "_start|kernel_main"
```

**Result**: ✅ Entry points correctly defined

## Known Limitations

⚠️ **Important**: Current `boot.asm` is a **32-bit placeholder**. It does not include:
- 64-bit long mode transition
- Paging initialization
- CPUID/long mode checks

These will be implemented in **#003 (x86-64 Entry Point)**, which will replace `boot.asm` with proper `entry.asm` and `boot64.asm`.

## Dependencies

- ✅ #001 - Cargo workspace setup (completed)
- ⬜ #003 - x86-64 entry point (next)

## Next Steps

After merging this PR:

1. **Immediate**: Implement #003 (x86-64 Entry Point)
   - Replace `boot.asm` with `entry.asm` (32-bit→64-bit transition)
   - Add `boot64.asm` (64-bit entry point)
   - Add paging initialization
   - Add CPUID/long mode checks

2. **Testing**: Boot test with QEMU + GRUB2
   - Create ISO image
   - Verify boot sequence
   - Test memory map parsing

3. **Enhancement**: Implement Multiboot2 information parsing
   - Parse memory map tags
   - Parse framebuffer information
   - Add boot information logging

## Checklist

- [x] Code compiles without errors
- [x] Multiboot2 header correctly placed at 0x100000
- [x] Entry point (_start) correctly defined at 0x101000
- [x] Build system (build.rs) compiles assembly files
- [x] Linker script updated for section placement
- [x] All new files follow project coding standards (English comments)
- [ ] Boot tested with QEMU + GRUB2 (requires #003)
- [ ] Memory map parsing implemented (future work)
- [ ] Documentation updated (excluded from commits)

## Review Notes

### For Reviewers

1. **Architecture Decision**: Boot code is kept in separate assembly files rather than inline assembly. This is intentional for:
   - Boot code runs before Rust runtime initialization
   - Clear separation of boot stages
   - Educational value and maintainability
   - Follows Redox OS philosophy

2. **Incomplete Boot Sequence**: Current implementation is foundational. The actual 64-bit mode transition will be in #003.

3. **Documentation**: `docs/implementation-notes/M1-1.2-multiboot2-completion.md` exists locally but is excluded from commits per `.gitignore`.

### Breaking Changes

None. This is new functionality.

### Performance Impact

None. Boot code runs once at startup.

## References

- [Multiboot2 Specification](https://www.gnu.org/software/grub/manual/multiboot2/multiboot.html)
- [OSDev Wiki - Multiboot](https://wiki.osdev.org/Multiboot)
- [Writing an OS in Rust](https://os.phil-opp.com/)
- Redox OS architecture documentation