### PR TITLE
[M1-1.2.2] Higher Half Kernel Preparation

### DIFF
--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -1,35 +1,54 @@
 ENTRY(_start)
 
+OUTPUT_FORMAT(elf64-x86-64)
+
 SECTIONS {
     . = 1M;
 
-    .boot :
+    __kernel_physical_start = .;
+
+    .multiboot2 ALIGN(8) : AT(ADDR(.multiboot2))
     {
         KEEP(*(.multiboot2))
-        KEEP(*(.multiboot_header))
+    }
+
+    .boot ALIGN(4K) : AT(ADDR(.boot))
+    {
+        KEEP(*(.boot))
+        KEEP(*(.text._start))
     }
 
     .text : ALIGN(4K)
     {
+        __text_start = .;
         KEEP(*(.text._start))
         *(.text .text.*)
+        __text_end = .;
     }
 
     .rodata : ALIGN(4K)
     {
+        __rodata_start = .;
         *(.rodata .rodata.*)
+        __rodata_end = .;
     }
 
     .data : ALIGN(4K)
     {
+        __data_start = .;
         *(.data .data.*)
+        __data_end = .;
     }
 
     .bss : ALIGN(4K)
     {
+        __bss_start = .;
         *(COMMON)
         *(.bss .bss.*)
+        __bss_end = .;
     }
+
+    __kernel_physical_end = .;
 
     /DISCARD/ :
     {

--- a/kernel/src/boot/entry.asm
+++ b/kernel/src/boot/entry.asm
@@ -7,7 +7,7 @@ stack_bottom:
     resb 16384  ; 16KB stack
 stack_top:
 
-section .text._start
+section .boot
 bits 32
 _start:
     ; Set up stack pointer
@@ -89,10 +89,15 @@ check_long_mode:
 
 ; Set up page tables
 setup_page_tables:
-    ; P4 table: Set pointer to P3 table
+    ; P4 table: Set up identity mapping (P4[0])
     mov eax, p3_table
     or eax, 0b11  ; present + writable
     mov [p4_table], eax
+
+    ; P4 table: Set up higher half mapping (P4[511])
+    mov eax, p3_table
+    or eax, 0b11
+    mov [p4_table + 511 * 8], eax
 
     ; P3 table: Set pointer to P2 table
     mov eax, p2_table


### PR DESCRIPTION
## Summary

Prepares the boot infrastructure and linker script for Higher Half Kernel implementation by adding section boundary symbols, separating multiboot2 and boot sections, and enhancing page table setup to support both identity and higher half address mapping. This establishes the foundation required for full Higher Half Kernel implementation in #004.

**Related Issue**: #17

## Changes

### Modified Files

#### `kernel/linker.ld`

**Added OUTPUT_FORMAT:**
- Specified `OUTPUT_FORMAT(elf64-x86-64)` at the beginning
- Ensures correct ELF format for x86_64 architecture

**Section Separation:**
- Split combined `.boot` section into:
  - `.multiboot2` section (8-byte aligned) - Multiboot2 header only
  - `.boot` section (4K aligned) - 32-bit boot code (`_start` entry point)
- Added explicit `AT(ADDR(...))` directives for physical memory placement

**Section Boundary Symbols:**
- `__kernel_physical_start` - Kernel start (0x100000 / 1M)
- `__kernel_physical_end` - Kernel end
- `__text_start` / `__text_end` - Text section boundaries
- `__rodata_start` / `__rodata_end` - Read-only data boundaries
- `__data_start` / `__data_end` - Data section boundaries
- `__bss_start` / `__bss_end` - BSS section boundaries

These symbols enable:
- Runtime kernel size calculation
- Memory management initialization
- Section-aware debugging
- Future virtual memory management

#### `kernel/src/boot/entry.asm`

**Section Annotation:**
- Changed `section .text._start` to `section .boot`
- Aligns with new linker script section layout
- Ensures proper placement in physical memory

**Page Table Enhancement:**
- Added P4[511] mapping for higher half kernel (0xFFFFFFFF80000000+)
- Preserved P4[0] identity mapping for boot compatibility
- Both entries point to the same P3 table, mapping first 1GB to both:
  - Physical addresses: 0x00000000 - 0x3FFFFFFF
  - Higher half addresses: 0xFFFFFFFF80000000 - 0xFFFFFFFFBFFFFFFF

This dual mapping enables smooth transition from identity-mapped boot code to higher half kernel execution.

## Implementation Details

### New Memory Layout

```
Physical Address    Virtual Addresses                Section          Content
0x100000           0x100000                          .multiboot2      Multiboot2 header (80 bytes)
0x101000           0x101000                          .boot            32-bit entry point (_start)
0x102000           0x102000                          .text            64-bit kernel code
                   0xFFFFFFFF80002000 (future)
0x103000           0x103000                          .rodata          Read-only data, GDT
                   0xFFFFFFFF80003000 (future)
0x104000           0x104000                          .data            Initialized data
                   0xFFFFFFFF80004000 (future)
0x104000           0x104000                          .bss             Uninitialized data
                   0xFFFFFFFF80004000 (future)                        - Page tables (12KB)
                                                                       - Stack (16KB)
```

### Page Table Structure (Enhanced)

```
P4 (PML4) Table [BSS: p4_table]
  Entry 0   → P3 Table [p3_table]  (Identity mapping)
  Entry 511 → P3 Table [p3_table]  (Higher half mapping) ← NEW

P3 (PDPT) Table [BSS: p3_table]
  Entry 0 → P2 Table [p2_table]

P2 (PD) Table [BSS: p2_table]
  Entry 0-511 → 2MB pages (physical 0x000000 - 0x3FE00000)
  Total mapped: 1GB
```

**Mapping Result:**
- Physical 0x00000000-0x3FFFFFFF → Virtual 0x00000000-0x3FFFFFFF (identity)
- Physical 0x00000000-0x3FFFFFFF → Virtual 0xFFFFFFFF80000000-0xFFFFFFFFBFFFFFFF (higher half)

### Section Verification

**Build Output:**
```
Idx Name          Size      VMA               LMA               File off  Algn
  0 .multiboot2   00000050  0000000000100000  0000000000100000  00000190  2**3
  1 .boot         0000010b  0000000000101000  0000000000101000  000001e0  2**0
  2 .text         00000086  0000000000102000  0000000000102000  00001000  2**12
  3 .rodata       0000001a  0000000000103000  0000000000103000  00002000  2**12
  4 .data         00000000  0000000000104000  0000000000104000  00003000  2**12
  5 .bss          00007000  0000000000104000  0000000000104000  00003000  2**12
```

**Symbol Table:**
```
0000000000100000 R __kernel_physical_start
0000000000102000 T __text_start
0000000000102086 T __text_end
0000000000103000 R __rodata_start
000000000010301a R __rodata_end
0000000000104000 B __bss_start
0000000000104000 R __data_end
0000000000104000 R __data_start
000000000010b000 B __bss_end
000000000010b000 B __kernel_physical_end
```

## Testing

### Build Verification
```bash
$ cargo build
   Compiling yomi-kernel v0.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.48s
```
✅ Build successful with no linker errors

### Section Layout Verification
```bash
$ objdump -h target/x86_64-unknown-none/debug/yomi-kernel
```
✅ `.multiboot2` appears at 0x100000 with 8-byte alignment
✅ `.boot` section separate at 0x101000 with 4K alignment
✅ All sections properly aligned

### Symbol Verification
```bash
$ nm target/x86_64-unknown-none/debug/yomi-kernel | grep "__kernel\|__text\|__rodata\|__data\|__bss"
```
✅ All 10 section boundary symbols defined
✅ Addresses are sequential and properly aligned

### ELF Program Headers
```bash
$ readelf -l target/x86_64-unknown-none/debug/yomi-kernel
```
✅ Entry point at 0x101000 (`.boot` section)
✅ Separate LOAD segments for each section
✅ Correct flags (R, R E, RW) for each segment

### Multiboot2 Header Verification
```bash
$ objdump -s -j .multiboot2 target/x86_64-unknown-none/debug/yomi-kernel
```
✅ Magic number 0xE85250D6 at offset 0x100000
✅ Header correctly placed at beginning of binary

## Benefits

### For Issue #004 (Full Higher Half Kernel)
- **Section symbols** enable kernel to know its own memory boundaries
- **Dual page mapping** allows seamless transition to higher half
- **Proper section separation** prepares for AT() directive usage in higher half mapping
- **OUTPUT_FORMAT** ensures correct ELF generation for virtual addressing

### For Future Development
- **Memory allocator** can use `__kernel_end` to find free memory start
- **Virtual memory manager** can use section boundaries for permission setup
- **Debugging** improved with named section boundaries
- **Security** foundation for W^X (write XOR execute) protection

## Compatibility

- ✅ Backward compatible with existing boot flow
- ✅ Identity mapping preserved for boot code execution
- ✅ No changes to Rust kernel code required
- ✅ QEMU and GRUB2 compatible
- ✅ Multiboot2 compliant

## Next Steps

After this PR is merged:
1. Implement full Higher Half Kernel in #004
2. Update linker script to use virtual addressing (0xFFFFFFFF80000000)
3. Modify kernel entry to switch from identity to higher half mapping
4. Update all kernel code to use virtual addresses

## Dependencies

- ✅ #001 (Cargo workspace setup)
- ✅ #002 (Multiboot2 header)
- ✅ #003 (x86_64 entry point)

## Blocks

- #004 (Linker script / Full Higher Half Kernel)

## Checklist

- [x] OUTPUT_FORMAT added to linker script
- [x] `.multiboot2` and `.boot` sections separated
- [x] Section boundary symbols defined (10 symbols)
- [x] entry.asm updated to use `.boot` section
- [x] Page table setup enhanced for higher half (P4[511])
- [x] Build successful without errors
- [x] Section layout verified with objdump
- [x] Symbols verified with nm
- [x] Memory layout verified with readelf
- [x] Multiboot2 header placement verified
- [x] Documentation created (issue #003.2)
- [x] Code committed to feature branch
- [x] Changes pushed to remote

## Notes

This is an incremental preparation step toward Higher Half Kernel. The implementation maintains full backward compatibility while adding the infrastructure needed for virtual address space management. All changes are additive and do not break existing functionality.

The page table dual mapping is critical - without P4[511], the kernel would triple-fault when attempting to execute code mapped to higher half addresses.